### PR TITLE
Fix bug when grape is installed but not loaded

### DIFF
--- a/lib/matic-jwt.rb
+++ b/lib/matic-jwt.rb
@@ -5,7 +5,7 @@ require 'matic-jwt/authenticator'
 require 'matic-jwt/generator'
 require 'matic-jwt/version'
 
-if Gem::Specification.find_all_by_name('grape').present?
+if Gem.loaded_specs.has_key?('grape')
   require 'matic-jwt/grape/helper'
   require 'matic-jwt/grape/middleware/request'
   require 'matic-jwt/grape/middleware/auth'


### PR DESCRIPTION
Before:
If you have installed grape in your system `Gem::Specification.find_all_by_name('grape').present?` will return `true`. But if grape is not loaded, `require matic-jwt/grape/middleware/auth` will raise exception `NameError (uninitialized constant Grape)`
After:
We should check if `grape` is loaded (not installed) to prevent the exception